### PR TITLE
Specify JMAP version to use rfc-8621

### DIFF
--- a/charts/inbox-server/configs/jmap.properties
+++ b/charts/inbox-server/configs/jmap.properties
@@ -1,5 +1,5 @@
 # Configuration file for JMAP
-
+jmap.version.default=rfc-8621
 enabled=${env:JAMES_JMAP_ENABLED}
 tls.keystoreURL=file://keystore
 tls.secret=${env:JAMES_KEYSTORE_PASSWORD}


### PR DESCRIPTION
This configuration is unnecessary in the latest versions of apache/james-project@master, as jmap-draft version has been removed.